### PR TITLE
Create react gears date widget based on fluent version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33533,6 +33533,7 @@
       }
     },
     "packages/react-gears": {
+      "name": "@rjsf/react-gears",
       "version": "5.13.0",
       "license": "MIT",
       "dependencies": {

--- a/packages/react-gears/src/widgets/DateWidget/DateWidget.tsx
+++ b/packages/react-gears/src/widgets/DateWidget/DateWidget.tsx
@@ -1,0 +1,73 @@
+import { FocusEvent } from 'react';
+import {
+  ariaDescribedByIds,
+  labelValue,
+  pad,
+  FormContextType,
+  RJSFSchema,
+  StrictRJSFSchema,
+  WidgetProps,
+} from '@rjsf/utils';
+
+import { DateInput } from '@appfolio/react-gears';
+
+// TODO: move to utils.
+// TODO: figure out a standard format for this, as well as
+// how we can get this to work with locales.
+const formatDate = (date?: Date) => {
+  if (!date) {
+    return '';
+  }
+  const yyyy = pad(date.getFullYear(), 4);
+  const MM = pad(date.getMonth() + 1, 2);
+  const dd = pad(date.getDate(), 2);
+  return `${yyyy}-${MM}-${dd}`;
+};
+
+const parseDate = (dateStr?: string) => {
+  if (!dateStr) {
+    return undefined;
+  }
+  const [year, month, day] = dateStr.split('-').map((e) => parseInt(e));
+  const dt = new Date(year, month - 1, day);
+  return dt;
+};
+
+export default function DateWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>({
+  id,
+  required,
+  label,
+  hideLabel,
+  value,
+  onChange,
+  onBlur,
+  onFocus,
+  placeholder,
+}: WidgetProps<T, S, F>) {
+  const _onSelectDate = (date: Date | null | undefined) => {
+    if (date) {
+      const formatted = formatDate(date);
+      formatted && onChange(formatted);
+    }
+  };
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLInputElement>) => onBlur(id, value);
+  const _onFocus = ({ target: { value } }: FocusEvent<HTMLInputElement>) => onFocus(id, value);
+
+  return (
+    <>
+      <DateInput
+        id={id}
+        className='mb-1'
+        placeholder={placeholder}
+        required={required}
+        // @ts-expect-error todo: TS2322: Type 'string | false | ReactElement<any, string | JSXElementConstructor<any>> | undefined' is not assignable to type 'string | undefined'.
+        label={labelValue(label, hideLabel)}
+        onSelectDate={_onSelectDate}
+        onBlur={_onBlur}
+        onFocus={_onFocus}
+        value={parseDate(value)}
+        aria-describedby={ariaDescribedByIds<T>(id)}
+      />
+    </>
+  );
+}

--- a/packages/react-gears/src/widgets/DateWidget/index.ts
+++ b/packages/react-gears/src/widgets/DateWidget/index.ts
@@ -1,0 +1,2 @@
+export { default } from './DateWidget';
+export * from './DateWidget';

--- a/packages/react-gears/src/widgets/generateWidgets.ts
+++ b/packages/react-gears/src/widgets/generateWidgets.ts
@@ -1,4 +1,5 @@
 import CheckboxWidget from './CheckboxWidget';
+import DateWidget from './DateWidget';
 import { FormContextType, RegistryWidgetsType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
 
 export function generateWidgets<
@@ -8,6 +9,7 @@ export function generateWidgets<
 >(): RegistryWidgetsType<T, S, F> {
   return {
     CheckboxWidget,
+    DateWidget,
   };
 }
 


### PR DESCRIPTION
### Reasons for making this change

[Please describe them here]

If this is related to existing tickets, include links to them as well. Use the syntax `fixes #[issue number]` (ex: `fixes #123`).

If your PR is non-trivial and you'd like to schedule a synchronous review, please add it to the weekly meeting agenda: https://docs.google.com/document/d/12PjTvv21k6LIky6bNQVnsplMLLnmEuypTLQF8a-8Wss/edit

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
